### PR TITLE
現在の資産をリタイア年数に計算に含める変更

### DIFF
--- a/app/models/asset_config.rb
+++ b/app/models/asset_config.rb
@@ -2,17 +2,18 @@
 # monthly_purchase: 月々の購入額
 
 class AssetConfig
-  attr_accessor :monthly_purchase, :annual_yield, :monthly_yield
+  attr_accessor :initial_asset, :monthly_purchase, :annual_yield, :monthly_yield
 
 
   def initialize(params)
+    @initial_asset = params[:initial_asset].to_i
     @monthly_purchase = params[:monthly_purchase].to_i
     @annual_yield = params[:annual_yield].to_i
     @monthly_yield = monthly_yield_calc
   end
 
   def self.test_case
-    self.new(monthly_purchase: 15, annual_yield: 5)
+    self.new(monthly_purchase: 15, annual_yield: 5, initial_asset: 100)
   end
 
   private

--- a/app/models/asset_formation_calc.rb
+++ b/app/models/asset_formation_calc.rb
@@ -2,7 +2,7 @@ class AssetFormationCalc
   attr_accessor :asset_sum, :asset_config
 
   def initialize(config)
-    @asset_sum ||= 0
+    @asset_sum ||= config.initial_asset
     @asset_config = config
   end
 


### PR DESCRIPTION
## what
- 設定値クラスに現在の資産の設定値を追加。
- X年後の資産計算クラスの資産初期値に、上記で追加した設定値を代入する。

## why
現在からリタイアまでの年数を計算する機能のために必要
