### PR TITLE
リタイア必要資産をオブジェクトに格納できるように修正

### DIFF
--- a/app/models/retirement_asset_calc.rb
+++ b/app/models/retirement_asset_calc.rb
@@ -3,8 +3,6 @@
 class RetirementAssetCalc < ApplicationRecord
   before_save :calculate!
 
-  attr_accessor :retirement_asset
-
   def self.test_case
     new(monthly_living_cost: 10, annual_yield: 5)
   end


### PR DESCRIPTION
## what

## why
- リタイア日数の表示機能のために必要