### PR TITLE
期待利率クラスを各種計算クラスに導入

### DIFF
--- a/app/models/asset_config.rb
+++ b/app/models/asset_config.rb
@@ -2,21 +2,7 @@
 # monthly_purchase: 月々の購入額
 
 class AssetConfig < ApplicationRecord
-  attr_accessor :monthly_yield
-  after_find :set_monthly_yield
-
-  def set_monthly_yield
-    monthly_yield = monthly_yield_calc
-  end
-
   def self.test_case
-    self.new(monthly_purchase: 15, annual_yield: 5, initial_asset: 100)
-  end
-
-  private
-
-  def monthly_yield_calc
-    yield_after_a_year = (1 + annual_yield.to_r * 0.01)
-    yield_after_a_year ** (1.0/12)
+    self.new(monthly_purchase: 15, initial_asset: 100)
   end
 end

--- a/app/models/retirement_asset_calc.rb
+++ b/app/models/retirement_asset_calc.rb
@@ -1,10 +1,15 @@
 # monthly_living_cost: (万円/月)
 
 class RetirementAssetCalc < ApplicationRecord
-  before_save :calculate!
+  attr_accessor :yield_config, :retirement_asset
+  # after_find :calculate!
+
+  def load_yield_config(yield_config)
+    @yield_config = yield_config
+  end
 
   def self.test_case
-    new(monthly_living_cost: 10, annual_yield: 5)
+    new(monthly_living_cost: 10)
   end
 
   def calculate!
@@ -16,6 +21,6 @@ class RetirementAssetCalc < ApplicationRecord
   end
 
   def yield_including_tax
-    annual_yield.to_r * 0.01r * tax_rate.to_r * 0.01r
+    yield_config.annual_yield.to_r * 0.01r * tax_rate.to_r * 0.01r
   end
 end

--- a/app/views/asset_config/edit.html.erb
+++ b/app/views/asset_config/edit.html.erb
@@ -16,12 +16,6 @@
       <%= f.number_field :monthly_purchase %>
     </div>
     <div>
-      期待年利(%)
-    </div>
-    <div>
-      <%= f.number_field :annual_yield, value: 5 %>
-    </div>
-    <div>
       <%= f.submit "設定する" %>
     </div>
   <% end %>

--- a/app/views/asset_config/new.html.erb
+++ b/app/views/asset_config/new.html.erb
@@ -16,12 +16,6 @@
       <%= f.number_field :monthly_purchase %>
     </div>
     <div>
-      期待年利(%)
-    </div>
-    <div>
-      <%= f.number_field :annual_yield, value: 5 %>
-    </div>
-    <div>
       <%= f.submit "設定する" %>
     </div>
   <% end %>

--- a/app/views/retirement_asset_calc/edit.html.erb
+++ b/app/views/retirement_asset_calc/edit.html.erb
@@ -16,12 +16,6 @@
       <%= f.number_field :tax_rate, value: 80 %>
     </div>
     <div>
-      期待年利(%)
-    </div>
-    <div>
-      <%= f.number_field :annual_yield, value: 5 %>
-    </div>
-    <div>
       <%= f.submit "設定する" %>
     </div>
   <% end %>

--- a/app/views/retirement_asset_calc/new.html.erb
+++ b/app/views/retirement_asset_calc/new.html.erb
@@ -16,12 +16,6 @@
       <%= f.number_field :tax_rate, value: 80 %>
     </div>
     <div>
-      期待年利(%)
-    </div>
-    <div>
-      <%= f.number_field :annual_yield, value: 5 %>
-    </div>
-    <div>
       <%= f.submit "設定する" %>
     </div>
   <% end %>

--- a/db/ridgepole.rb
+++ b/db/ridgepole.rb
@@ -3,15 +3,11 @@
 create_table "asset_configs", force: :cascade do |t|
   t.string "initial_asset", null: :false, default: 0
   t.string "monthly_purchase", null: :false, default: 0
-  t.string "annual_yield", null: :false, default: 0
-  # t.float "monthly_yield", null: :false, default: 0
 end
 
 create_table "retirement_asset_calcs", force: :cascade do |t|
   t.string "monthly_living_cost", null: :false, default: 0
-  t.string "annual_yield", null: :false, default: 0
   t.string "tax_rate", null: :false, default: 80
-  t.string "retirement_asset", null: :false, default: 0
 end
 
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,14 +15,11 @@ ActiveRecord::Schema.define(version: 0) do
   create_table "asset_configs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "initial_asset", default: "0"
     t.string "monthly_purchase", default: "0"
-    t.string "annual_yield", default: "0"
   end
 
   create_table "retirement_asset_calcs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "monthly_living_cost", default: "0"
-    t.string "annual_yield", default: "0"
     t.string "tax_rate", default: "80"
-    t.string "retirement_asset", default: "0"
   end
 
   create_table "yield_configs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|


### PR DESCRIPTION
## what
- AssetConfigクラスとリタイア必要額の計算クラスから期待年利のカラムを削除。
- 設定フォームから期待利率の値を削除

## why
- 期待年利の設定値クラス導入することでDBの正規化をすすめる