### PR TITLE
ログイン複数回失敗時のアカウントロック機能を追加

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
-         :confirmable
+         :confirmable, :lockable
 
   has_one :asset_config
   has_one :yield_config

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -204,11 +204,11 @@ Devise.setup do |config|
   # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
   # :both  = Enables both strategies
   # :none  = No unlock strategy. You should handle unlocking by yourself.
-  # config.unlock_strategy = :both
+  config.unlock_strategy = :email
 
   # Number of authentication tries before locking an account if lock_strategy
   # is failed attempts.
-  # config.maximum_attempts = 20
+  config.maximum_attempts = 4
 
   # Time interval to unlock the account if :time is enabled as unlock_strategy.
   # config.unlock_in = 1.hour

--- a/db/ridgepole.rb
+++ b/db/ridgepole.rb
@@ -44,9 +44,9 @@ create_table "users", force: :cascade do |t|
   t.string   "unconfirmed_email" # Only if using reconfirmable
 
   ## Lockable
-  # t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
-  # t.string   :unlock_token # Only if unlock strategy is :email or :both
-  # t.datetime :locked_at
+  t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
+  t.string   :unlock_token # Only if unlock strategy is :email or :both
+  t.datetime :locked_at
 
   t.timestamps
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -34,6 +34,9 @@ ActiveRecord::Schema.define(version: 0) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
+    t.integer "failed_attempts", default: 0, null: false
+    t.string "unlock_token"
+    t.datetime "locked_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
## what
- Userモデルにてアカウントロック機能をON
- 必要なカラムをusersテーブルに追加

## why
- ユーザ認証の信頼性を最低限担保するため