### PR TITLE
ログイン認証時にJWTトークンを生成してレスポンスを返す仕様に変更。

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,3 +66,6 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'ridgepole'
 gem 'devise'
 gem 'jsonapi-serializer'
+gem 'jwt'
+gem 'bcrypt', '~> 3.1.7'
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,7 @@ GEM
       activesupport (>= 5.0.0)
     jsonapi-serializer (2.1.0)
       activesupport (>= 4.2)
+    jwt (2.2.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -218,6 +219,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap (>= 1.1.0)
   byebug
   capybara (>= 2.15)
@@ -226,6 +228,7 @@ DEPENDENCIES
   devise
   jbuilder (~> 2.5)
   jsonapi-serializer
+  jwt
   listen (>= 3.0.5, < 3.2)
   mysql2 (>= 0.4.4, < 0.6.0)
   pry-byebug

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,7 @@
 class ApplicationController < ActionController::Base
+  include JwtAuthentication
+
+
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   def user_confirmed?

--- a/app/controllers/concerns/jwt_authentication.rb
+++ b/app/controllers/concerns/jwt_authentication.rb
@@ -1,0 +1,15 @@
+module JwtAuthentication
+  require 'jwt'
+
+  @@rsa_private = OpenSSL::PKey::RSA.generate(2048)
+  @@rsa_public = @@rsa_private.public_key
+
+  def issue(user_id)
+    @rsa_private = OpenSSL::PKey::RSA.generate 2048
+    @rsa_public = @rsa_private.public_key
+    expires_in = 1.month.from_now
+    payload = {user_id: user_id, exp: expires_in.to_i}
+
+    token = JWT.encode(payload, @rsa_private, 'RS256')
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  has_secure_token
+  has_secure_password
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
@@ -12,4 +12,6 @@ class User < ApplicationRecord
   has_one :asset_config
   has_one :yield_config
   has_one :retirement_asset_calc
+
+  def password_digest; encrypted_password; end
 end


### PR DESCRIPTION
## what
- gem 'jwt'を導入
- jwtトークンのencode、decodeメソッドを追加

## why
- ステートレス化