### PR TITLE
【APIコントローラ】ログイン認証時のエラーハンドリング修正

### DIFF
--- a/app/controllers/api/v1/root_controller.rb
+++ b/app/controllers/api/v1/root_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::RootController < ApplicationController
 
   def index
     jwt_token = issue(17)
-    binding.pry
+    # binding.pry
     if jwt_token
       payload = decode(jwt_token)
       user = User.find(payload[0]["sub"])

--- a/app/controllers/api/v1/users/sessions_controller.rb
+++ b/app/controllers/api/v1/users/sessions_controller.rb
@@ -3,36 +3,25 @@ class Api::V1::Users::SessionsController < Devise::SessionsController
   protect_from_forgery :except => [:create, :failed]
 
   def create
-    binding.pry
     user = User.find_by(email: user_params[:email])
-    redirect_to :failed unless user
 
-    if user.authenticate(user_params[:password])
+    if user&.authenticate(user_params[:password])
       jwt_token = issue(user.id)
       response.headers['X-Authentication-Token'] = jwt_token
 
       session_response = SessionResponse.new(status: 'success', message: "signed in as #{user.nickname}", user_id: user.id)
       serializer = SessionResponseSerializer.new(session_response)
+
       render json: serializer.serializable_hash.to_json
     else
-      redirect_to :failed
+      message = 'メールアドレスまたはパスワードが間違っています'
+      session_response = SessionResponse.new(status: 'error', message: message)
+      serializer = SessionResponseSerializer.new(session_response)
+      render json: serializer.serializable_hash.to_json
     end
   end
 
-  def failed
-    message = 'メールアドレスまたはパスワードが間違っています'
-    session_response = SessionResponse.new(status: 'error', message: messages)
-    serializer = SessionResponseSerializer.new(session_response)
-    render json: serializer.serializable_hash.to_json
-  end
-
   protected
-
-  def auth_options
-    # 失敗時に recall に設定したパスのアクションが呼び出されるので変更
-    # { scope: resource_name, recall: "#{controller_path}#new" } # デフォルト
-    { scope: :user, recall: "#{controller_path}#failed" }
-  end
 
   def user_params
     params.require(:user).permit(:email, :password)


### PR DESCRIPTION
## what
- ログイン失敗時＝メルアドが存在しない、パスワード間違い、どちらの場合でもエラー時レスポンスを送るように変更
- その他不要なコードを削除

## why
- 適切なエラーハンドリングのため