### PR TITLE
【API】設定値の登録機能の修正

### DIFF
--- a/app/controllers/api/v1/config_controller.rb
+++ b/app/controllers/api/v1/config_controller.rb
@@ -23,10 +23,6 @@ class Api::V1::ConfigController < ApplicationController
   private
 
   def asset_config_params
-    params.require(:asset_config).permit(:initial_asset, :monthly_purchase).merge(user: @user)
-  end
-
-  def yield_config_params
-    params.require(:yield_config).permit(:annual_yield).merge(user: @user)
+    params.require(:asset_config).permit(:initial_asset, :monthly_purchase, :annual_yield).merge(user: @user)
   end
 end

--- a/app/controllers/api/v1/users/sign_in_controller.rb
+++ b/app/controllers/api/v1/users/sign_in_controller.rb
@@ -2,6 +2,7 @@ class Api::V1::Users::SignInController < ApplicationController
   protect_from_forgery :except => [:create]
 
   def create
+    binding.pry
     user = User.find_by(email: user_params[:email])
 
     if user&.authenticate(user_params[:password])

--- a/app/models/asset_config.rb
+++ b/app/models/asset_config.rb
@@ -5,7 +5,7 @@ class AssetConfig < ApplicationRecord
   belongs_to :user
   has_one :yield_config, through: :user
 
-  validates :initial_asset, :monthly_purchase, presence: true
+  validates :initial_asset, :monthly_purchase, :annual_yield, presence: true
 
   def self.test_case
     self.new(monthly_purchase: 15, initial_asset: 100)


### PR DESCRIPTION
## what
- annual_yieldに関するストロングパラメータとバリデーションを追加。
- 元のyield_configに関するストロングパラメータを削除

## why
- annual_yieldカラムの更新ができないエラーを修正