### PR TITLE
【API】ユーザー認証情報に紐づく設定値を返すAPIを実装

### DIFF
--- a/app/controllers/api/v1/config_controller.rb
+++ b/app/controllers/api/v1/config_controller.rb
@@ -1,6 +1,12 @@
 class Api::V1::ConfigController < ApplicationController
   before_action :authenticate
 
+  def new
+    asset_config = AssetConfig.find_or_initialize_by(user_id: @user.id)
+    serializer = AssetConfigSerializer.new(asset_config)
+    render json: serializer.serializable_hash.to_json
+  end
+
   def create
     if @user
       asset_config = AssetConfig.find_by_user_or_initialize(asset_config_params)

--- a/app/controllers/api/v1/retirement_asset_config_controller.rb
+++ b/app/controllers/api/v1/retirement_asset_config_controller.rb
@@ -1,6 +1,12 @@
 class Api::V1::RetirementAssetConfigController < ApplicationController
   before_action :authenticate
 
+  def new
+    retirement_asset_calc = RetirementAssetCalc.find_or_initialize_by(user_id: @user.id)
+    serializer = RetirementAssetCalcSerializer.new(retirement_asset_calc)
+    render json: serializer.serializable_hash.to_json
+  end
+
   def create
     if @user
       asset_config = RetirementAssetCalc.find_by_user_or_initialize(retirement_asset_calc_params)

--- a/app/serializers/asset_config_serializer.rb
+++ b/app/serializers/asset_config_serializer.rb
@@ -1,0 +1,5 @@
+class AssetConfigSerializer
+  include JSONAPI::Serializer
+
+  attributes :initial_asset, :monthly_purchase, :annual_yield
+end

--- a/app/serializers/retirement_asset_calc_serializer.rb
+++ b/app/serializers/retirement_asset_calc_serializer.rb
@@ -1,0 +1,5 @@
+class RetirementAssetCalcSerializer
+  include JSONAPI::Serializer
+
+  attributes :monthly_living_cost, :tax_rate, :annual_yield
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,8 +17,8 @@ Rails.application.routes.draw do
     namespace :v1 do
       root 'root#index'
       devise_for :users, controllers: { registrations: 'api/v1/users/registrations', confirmations: 'api/v1/users/confirmations', sessions: 'api/v1/users/sessions' }
-      resources :config, only: :create
-      resources :retirement_asset_config, only: :create
+      resources :config, only: [:new, :create]
+      resources :retirement_asset_config, only: [:new, :create]
       namespace :users do
         resources :sign_up, only: :create
         resources :sign_in, only: :create


### PR DESCRIPTION
## what
メイン設定値とリタイア額計算設定値について、既存のレコードが存在する場合に返すAPIを実装
- ルーティング設定
- コントローラ実装
- シリアライザー実装

## why
- ユーザー設定値を変更したいときに、毎回入力しなければならない手間を避けるための実装が必要だから。その準備