### PR TITLE
【API】ホーム画面：リタイア年数計算の設定が不十分な場合の処理

### DIFF
--- a/app/models/asset_config.rb
+++ b/app/models/asset_config.rb
@@ -7,10 +7,6 @@ class AssetConfig < ApplicationRecord
 
   validates :initial_asset, :monthly_purchase, :annual_yield, presence: true
 
-  def self.test_case
-    self.new(monthly_purchase: 15, initial_asset: 100)
-  end
-
   def monthly_yield
     @monthly_yield ||= monthly_yield_calc
   end

--- a/app/models/asset_formation_calc.rb
+++ b/app/models/asset_formation_calc.rb
@@ -7,10 +7,6 @@ class AssetFormationCalc
     @count = 0
   end
 
-  def self.test_case
-    new(AssetConfig.test_case)
-  end
-
   def calculate(years_later)
     asset_after_years(years_later).asset_sum_round!
   end

--- a/app/models/rest_time_calc.rb
+++ b/app/models/rest_time_calc.rb
@@ -1,16 +1,19 @@
 class RestTimeCalc
-  attr_accessor :asset_formation, :asset_years, :asset_month, :retirement_asset, :user_id
+  include ActiveModel::Validations
 
-  def initialize(asset_formation = nil, retirement_asset_calc = nil, user_id = nil)
+  attr_accessor :asset_formation, :asset_years, :asset_month, :retirement_asset, :user_id, :asset_config
+  validates :asset_config, :retirement_asset, presence: true
+
+  def initialize(retirement_asset_calc = nil, user_id = nil, asset_config = nil)
     @user_id = user_id
-    @asset_formation = asset_formation
+    @asset_config = asset_config
     @retirement_asset = retirement_asset_calc
     @asset_years = 0
-    year_calc
+    year_calc if valid?
   end
 
-  def self.test_case
-    new(AssetFormationCalc.test_case, RetirementAssetCalc.test_case)
+  def asset_formation
+    @asset_formation ||= asset_formation_calc = AssetFormationCalc.new(asset_config)
   end
 
   def year_calc
@@ -19,10 +22,6 @@ class RestTimeCalc
       break self.asset_years = i + 1 if asset_formation.asset_after_one_year > retirement_asset.retirement_asset
     end
     self
-  end
-
-  def year_calc_test(years)
-    asset_formation.asset_after_years(years)
   end
 
   def user

--- a/app/models/rest_time_calc_builder.rb
+++ b/app/models/rest_time_calc_builder.rb
@@ -4,9 +4,6 @@ class RestTimeCalcBuilder
   def initialize(user)
     asset_config = user.asset_config
     retirement_asset_calc = user.retirement_asset_calc
-    if asset_config.present? && retirement_asset_calc.present?
-      asset_formation_calc = AssetFormationCalc.new(asset_config)
-      @rest_time_calc = RestTimeCalc.new(asset_formation_calc, retirement_asset_calc, user.id)
-    end
+    @rest_time_calc = RestTimeCalc.new(retirement_asset_calc, user.id, asset_config)
   end
 end

--- a/app/serializers/rest_time_calc_serializer.rb
+++ b/app/serializers/rest_time_calc_serializer.rb
@@ -3,6 +3,9 @@ class RestTimeCalcSerializer
 
   set_id :user_id
   attributes :asset_years
+  attributes :messages do |rest_time_calc|
+    rest_time_calc.errors.messages
+  end
 
   belongs_to :user, serializer: UserSerializer
 end

--- a/spec/models/rest_time_calc_spec.rb
+++ b/spec/models/rest_time_calc_spec.rb
@@ -3,8 +3,7 @@ require 'rails_helper'
 RSpec.describe RestTimeCalc, type: :model do
   describe 'year_calc' do
     include_context :user_with_rest_time_calc_config
-    let(:asset_formation_calc) { AssetFormationCalc.new(asset_config) }
-    let(:rest_time_calc) { RestTimeCalc.new(asset_formation_calc, retirement_asset_calc, user.id) }
+    let(:rest_time_calc) { RestTimeCalc.new(retirement_asset_calc, user.id, asset_config) }
     let(:result) { rest_time_calc.asset_years }
 
     context '必要な設定値が与えられている場合' do
@@ -23,6 +22,25 @@ RSpec.describe RestTimeCalc, type: :model do
 
         it '引退目標の資産額を下回っている' do
           is_expected.to be <= retirement_asset_calc.retirement_asset
+        end
+      end
+    end
+
+    context '必要な設定値が与えられていない場合' do
+      subject { rest_time_calc.errors.messages.size }
+      before { rest_time_calc.valid? }
+
+      context 'メイン設定値が与えられていない場合' do
+        let(:asset_config) { nil }
+        it 'バリデーションエラーが格納されている' do
+          is_expected.to eq 1
+        end
+      end
+
+      context 'リタイア額設定値が与えられていない場合' do
+        let(:retirement_asset_calc) { nil }
+        it 'バリデーションエラーが格納されている' do
+          is_expected.to eq 1
         end
       end
     end

--- a/spec/requests/root_spec.rb
+++ b/spec/requests/root_spec.rb
@@ -6,13 +6,37 @@ RSpec.describe "Root", :type => :request do
     require 'json'
     include JwtAuthentication
     let(:jwt_token) { issue(user.id)}
+    let(:headers) { { Authorization: jwt_token } }
+    before { get api_v1_root_path, headers: headers }
 
-    context "JWTトークンが渡された場合" do
-      let(:headers) { { Authorization: jwt_token } }
+    context "正常系" do
+      let(:messages) { JSON.parse(response.body).dig("data", "attributes").delete("messages") }
 
       it "RestTimeCalcクラスのオブジェクトがシリアライズされて返される" do
-        get api_v1_root_path, headers: headers
         expect(JSON.parse(response.body).dig("data", "type")).to eq "rest_time_calc"
+      end
+
+      it 'レスポンスにエラーメッセージが含まれている' do
+        expect(messages.present?).to be_falsey
+      end
+    end
+
+    context '未設定の値が存在する場合' do
+      let(:asset_config) { nil }
+      let(:messages) { JSON.parse(response.body).dig("data", "attributes").delete("messages") }
+
+      context 'メイン設定値が与えられていない場合' do
+        it 'レスポンスにエラーメッセージが含まれている' do
+          expect(messages.present?).to be_truthy
+        end
+      end
+
+      context 'リタイア額設定値が与えられていない場合' do
+        let(:retirement_asset_calc) { nil }
+
+        it 'レスポンスにエラーメッセージが含まれている' do
+          expect(messages.present?).to be_truthy
+        end
       end
     end
   end


### PR DESCRIPTION
## what
- テストケース：設定値が不十分についてスペック追加
- リタイアまでの日数計算クラスにバリデーション追加
- 上記のバリデーションの結果をレスポンスに追加
- テスト十分のため、テストメソッドを削除

## why
- 設定が不十分な場合に、ユーザーに対して案内を表示するため