### PR TITLE
【API】リタイア期間計算のレスポンスに月数を追加

### DIFF
--- a/app/serializers/rest_time_calc_serializer.rb
+++ b/app/serializers/rest_time_calc_serializer.rb
@@ -2,7 +2,7 @@ class RestTimeCalcSerializer
   include JSONAPI::Serializer
 
   set_id :user_id
-  attributes :asset_years
+  attributes :asset_years, :asset_months
   attributes :messages do |rest_time_calc|
     rest_time_calc.errors.messages
   end

--- a/spec/requests/root_spec.rb
+++ b/spec/requests/root_spec.rb
@@ -10,10 +10,15 @@ RSpec.describe "Root", :type => :request do
     before { get api_v1_root_path, headers: headers }
 
     context "正常系" do
-      let(:messages) { JSON.parse(response.body).dig("data", "attributes").delete("messages") }
+      let(:attributes) { JSON.parse(response.body).dig("data", "attributes") }
+      let(:messages) { attributes.delete("messages") }
 
       it "RestTimeCalcクラスのオブジェクトがシリアライズされて返される" do
         expect(JSON.parse(response.body).dig("data", "type")).to eq "rest_time_calc"
+      end
+
+      it "RestTimeCalcオブジェクトはasset_years, asset_months, messagesの3項目を返す" do
+        expect(attributes.keys).to eq ["asset_years", "asset_months", "messages"]
       end
 
       it 'レスポンスにエラーメッセージが含まれていない' do


### PR DESCRIPTION
## what
- シリアライザにアトリビュートを追加
- テスト修正

## why
- ユーザーにリタイアをより身近に感じてもらう目的