### PR TITLE
【エラーハンドリング】エラーメッセージの日本語化、整形

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,4 +71,3 @@ gem 'ridgepole'
 gem 'jsonapi-serializer'
 gem 'jwt'
 gem 'bcrypt', '~> 3.1.7'
-

--- a/app/controllers/api/v1/config_controller.rb
+++ b/app/controllers/api/v1/config_controller.rb
@@ -13,8 +13,7 @@ class Api::V1::ConfigController < ApplicationController
       if asset_config.save
         config_response = Response.new(status: 'success', message: "set configure as #{@user.nickname}", user_id: @user.id)
       else
-        messages = asset_config.errors.messages
-        config_response = Response.new(status: 'error', message: messages, user_id: @user.id)
+        config_response = Response.new(status: 'error', message: asset_config.errors.full_messages, user_id: @user.id)
       end
       serializer = ResponseSerializer.new(config_response)
       render json: serializer.serializable_hash.to_json

--- a/app/controllers/api/v1/retirement_asset_config_controller.rb
+++ b/app/controllers/api/v1/retirement_asset_config_controller.rb
@@ -13,8 +13,7 @@ class Api::V1::RetirementAssetConfigController < ApplicationController
       if asset_config.save
         config_response = Response.new(status: 'success', message: "set configure as #{@user.nickname}", user_id: @user.id)
       else
-        messages = asset_config.errors.messages
-        config_response = Response.new(status: 'error', message: messages, user_id: @user.id)
+        config_response = Response.new(status: 'error', message: asset_config.errors.full_messages, user_id: @user.id)
       end
       serializer = ResponseSerializer.new(config_response)
       render json: serializer.serializable_hash.to_json

--- a/app/controllers/api/v1/users/sign_up_controller.rb
+++ b/app/controllers/api/v1/users/sign_up_controller.rb
@@ -6,7 +6,7 @@ class Api::V1::Users::SignUpController < ApplicationController
     if user.save
       registration_response = Response.new(status: 'success', message: 'mail for confirmation has sent', user_id: user.id)
     else
-      registration_response = Response.new(status: 'error', message: user.errors.messages)
+      registration_response = Response.new(status: 'error', message: user.errors.full_messages)
     end
     serializer = ResponseSerializer.new(registration_response)
     render json: serializer.serializable_hash.to_json

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,10 +1,10 @@
 class User < ApplicationRecord
-  has_secure_password
+  has_secure_password validations: false
 
   validates :nickname, :email, :password, :password_confirmation, presence: true
   validates :nickname, :email, uniqueness: true
-  validates :email, format: { with: /[\w|\.]+@\w+\.[\w|\.]+/, message: "メールアドレスではありません" } # @を含む、ドメインには1文字以上"."が含まれる
-  validates :password, length: { in: 8..128 }, format: { with: /(?=.*?[a-z])(?=.*?[A-Z])(?=.*?\d).*/, message: "パスワードは数字、半角小文字、半角大文字を1文字ずつ以上含む必要があります" }
+  validates :email, format: { with: /[\w|\.]+@\w+\.[\w|\.]+/} # @を含む、ドメインには1文字以上"."が含まれる
+  validates :password, length: { in: 8..128 }, format: { with: /(?=.*?[a-z])(?=.*?[A-Z])(?=.*?\d).*/ }, confirmation: true
 
   has_one :asset_config
   has_one :yield_config

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,8 @@ module Mcalc
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
 
+    config.i18n.default_locale = :ja
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,42 @@
+ja:
+  activerecord:
+    models:
+      user: ユーザー
+    attributes:
+      user:
+        nickname: ニックネーム
+        email: メールアドレス
+        password: パスワード
+        password_confirmation: パスワード(確認用)
+      asset_config:
+        initial_asset: 現在の資産
+        monthly_purchase: 月々の積立額
+        annual_yield: 期待年利
+      retirement_asset_calc:
+        monthly_living_cost: 月々の生活費
+        tax_rate: 税引き後レート
+        annual_yield: 期待年利
+    errors:
+      models:
+        user:
+          attributes:
+            email:
+              invalid: "%{attribute}ではない値が入力されています"
+            password:
+              invalid: "%{attribute}は数字、半角小文字、半角大文字を1文字ずつ以上含む必要があります"
+        retirement_asset_calc:
+          attributes:
+            tax_rate:
+              greater_than: "%{attribute}は%{count}%より大きい値にしてください"
+              less_than_or_equal_to: "%{attribute}は%{count}%以下にしてください"
+  errors:
+    format: "%{message}"
+    messages:
+      blank: "%{attribute}を入力してください"
+      taken: "すでに使用されている%{attribute}です"
+      confirmation: "%{attribute}が一致しません"
+      too_short: "%{attribute}は%{count}文字以上にしてください"
+      too_long: "%{attribute}は%{count}文字以下にしてください"
+      greater_than: "%{attribute}は%{count}より大きい値にしてください"
+      not_a_number: "%{attribute}は数字を入力してください"
+      less_than_or_equal_to: "%{attribute}は%{count}以下の値にしてください"


### PR DESCRIPTION
## what
- i18n導入
- 各モデル名とエラーメッセージの日本語翻訳設定ファイルを作成
- コントローラでエラーメッセージとして渡す値を、full_messagesに変更。

## why
- わかりやすいエラーメッセージを渡すため
- エラーメッセージの整形をAPI側ですることで、フロントエンドの責務を表示のみに集中するため、full_messagesを渡す仕様とした
