### PR TITLE
【軽微な修正】クライアント側のパスワード変更機能に合わせた修正

### DIFF
--- a/app/controllers/api/v1/users/passwords_controller.rb
+++ b/app/controllers/api/v1/users/passwords_controller.rb
@@ -33,12 +33,12 @@ class Api::V1::Users::PasswordsController < ApplicationController
       if user.confirm_reset_password_token(params[:user][:reset_password_token])
         user.assign_attributes(reset_password_params)
         if user.save
-          response = Response.new(status: 'success', message: 'password has changed')
+          response = Response.new(status: 'success', message: ['パスワードを再設定しました'])
         else
           response = Response.new(status: 'error', message: user.errors.full_messages)
         end
       else
-        response = Response.new(status: 'error', message: user.errors.full_messages)
+        response = Response.new(status: 'not authenticated', message: user.errors.full_messages)
       end
       serializer = ResponseSerializer.new(response)
       render json: serializer.serializable_hash.to_json

--- a/app/models/concerns/user_reset_password_module.rb
+++ b/app/models/concerns/user_reset_password_module.rb
@@ -3,7 +3,7 @@ module UserResetPasswordModule
 
   def confirm_reset_password_token(token)
     if check_reset_password_expiration
-      erros.add(:reset_password_sent_at, :token_expiration) && false
+      errors.add(:reset_password_sent_at, :token_expiration) && false
     elsif check_reset_password_token(token)
       true
     else


### PR DESCRIPTION
## what
- typo修正
- パスワード変更時のエラー時にresponseを行う際のstatusをバリデーションエラーと認証エラーで分割。

## why
- UI改善のため、サーバーサイド側の機能修正