### PR TITLE
【不具合修正】jwtデコード時の不具合：トークン生成時刻確認エラー

### DIFF
--- a/app/controllers/concerns/jwt_authentication.rb
+++ b/app/controllers/concerns/jwt_authentication.rb
@@ -25,7 +25,7 @@ module JwtAuthentication
     end
 
     def payload
-      JWT.decode(token, certification(public_key), true, { algorithm: 'RS256', verify_iat: true })
+      JWT.decode(token, certification(public_key), true, { algorithm: 'RS256', verify_iat: false })
     end
 
     private


### PR DESCRIPTION
## what
- トークン生成時刻の確認をスキップする仕様に変更

## why
- OSの時刻がgoogleの時刻より早い場合にエラーが発生する
- 動作の不安定の元となるため、時刻の確認をスキップすることとした。