### PR TITLE
【バックエンド】最後の資産記録月からの経過期間を残り時間に計上

### DIFF
--- a/app/controllers/concerns/jwt_authentication.rb
+++ b/app/controllers/concerns/jwt_authentication.rb
@@ -25,17 +25,17 @@ module JwtAuthentication
     end
 
     def payload
-      JWT.decode(token, certification(public_key), true, { algorithm: 'RS256', verify_iat: false })
+      JWT.decode(token, certification, true, { algorithm: 'RS256', verify_iat: false })
     end
 
     private
 
-    def public_key
-      google_key_set[key_id]
+    def certification
+      OpenSSL::X509::Certificate.new(public_key).public_key
     end
 
-    def certification(public_key)
-      OpenSSL::X509::Certificate.new(public_key).public_key
+    def public_key
+      google_key_set[key_id]
     end
 
     def key_id

--- a/app/models/asset_record.rb
+++ b/app/models/asset_record.rb
@@ -4,6 +4,8 @@ class AssetRecord < ApplicationRecord
 	validates :date, presence: true
 	validates :date, uniqueness: { scope: :user_id }
 
+	scope :latest_users_asset, -> (user) { where(user_id: user.id).order(:date).last }
+
 	def date=(value)
 		super AssetRecordDate.new(value).date
 	end

--- a/app/models/rest_month_calc.rb
+++ b/app/models/rest_month_calc.rb
@@ -1,0 +1,27 @@
+class RestMonthCalc
+  include ActiveModel::Validations
+
+  attr_accessor :asset_config, :retirement_asset, :asset_record, :asset_months
+  validates :asset_config, :retirement_asset, presence: true
+
+  def initialize(retirement_asset_calc = nil, asset_config = nil, asset_record = nil)
+    @asset_config, @retirement_asset, @asset_record = asset_config, retirement_asset_calc, asset_record
+    @asset_months = 0
+    calculate! if valid?
+  end
+
+  def asset_formation
+    @asset_formation ||= AssetFormationCalc.new(asset_config, asset_record)
+  end
+
+  def calculate!
+    self.asset_months = rest_months_from_last_record
+  end
+
+  def rest_months_from_last_record
+    loop.with_index do |_, m|
+      break m + 1 if asset_config.asset_after_one_month(asset_formation.asset_sum) > retirement_asset.retirement_asset
+      asset_formation.asset_sum = asset_config.asset_after_one_month(asset_formation.asset_sum)
+    end
+  end
+end

--- a/app/models/rest_month_calc.rb
+++ b/app/models/rest_month_calc.rb
@@ -1,24 +1,18 @@
 class RestMonthCalc
   include ActiveModel::Validations
 
-  attr_accessor :asset_config, :retirement_asset, :asset_record, :asset_months
+  attr_reader :asset_config, :retirement_asset, :asset_record
   validates :asset_config, :retirement_asset, presence: true
 
   def initialize(retirement_asset_calc = nil, asset_config = nil, asset_record = nil)
     @asset_config, @retirement_asset, @asset_record = asset_config, retirement_asset_calc, asset_record
-    @asset_months = 0
-    calculate! if valid?
   end
 
   def asset_formation
     @asset_formation ||= AssetFormationCalc.new(asset_config, asset_record)
   end
 
-  def calculate!
-    self.asset_months = rest_months_from_last_record
-  end
-
-  def rest_months_from_last_record
+  def rest_months
     loop.with_index do |_, m|
       break m + 1 if asset_config.asset_after_one_month(asset_formation.asset_sum) > retirement_asset.retirement_asset
       asset_formation.asset_sum = asset_config.asset_after_one_month(asset_formation.asset_sum)

--- a/app/models/rest_time_calc.rb
+++ b/app/models/rest_time_calc.rb
@@ -15,13 +15,30 @@ class RestTimeCalc
   end
 
   def calculate!
-    loop.with_index do |_, i|
-      if asset_config.asset_after_one_month(asset_formation.asset_sum) > retirement_asset.retirement_asset
-        self.asset_years, self.asset_months = to_years_and_months(i + 1)
-        break
-      end
-      asset_formation.asset_sum = asset_config.asset_after_one_month(asset_formation.asset_sum)
-    end
+    self.asset_years, self.asset_months = to_years_and_months(rest_months_from_last_record)
+  end
+
+  def rest_months_from_last_record
+    RestMonthCalc.new(retirement_asset, asset_config, asset_record).asset_months
+  end
+
+  def rest_days(rest_months)
+    rest_months * 30 - passed_days
+  end
+
+  def passed_days
+    passed_unix_time / 60 / 60 / 24
+  end
+
+  def passed_unix_time
+    (Time.zone.now - asset_record.date).to_i 
+  end
+
+  # 登録日+残月数-現在
+  # 残月数-(現在-登録日)
+
+  def to_ymd(days)
+    [days / 30 / 12, days / 30 % 12, days % 30]
   end
 
   def to_years_and_months(months)

--- a/app/models/rest_time_calc_builder.rb
+++ b/app/models/rest_time_calc_builder.rb
@@ -4,7 +4,7 @@ class RestTimeCalcBuilder
   def initialize(user)
     asset_config = user.asset_config
     retirement_asset_calc = user.retirement_asset_calc
-    asset_record = user.asset_records.last
+    asset_record = AssetRecord.latest_users_asset(user)
     @rest_time_calc = RestTimeCalc.new(retirement_asset_calc, user.id, asset_config, asset_record)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,8 +3,4 @@ class User < ApplicationRecord
   has_one :yield_config
   has_one :retirement_asset_calc
   has_many :asset_records
-
-  def self.current_asset_record
-    asset_records.last
-  end
 end

--- a/app/serializers/rest_time_calc_serializer.rb
+++ b/app/serializers/rest_time_calc_serializer.rb
@@ -2,7 +2,7 @@ class RestTimeCalcSerializer
   include JSONAPI::Serializer
 
   set_id :user_id
-  attributes :rest_years, :rest_months
+  attributes :rest_years, :rest_months, :rest_days
   attributes :messages do |rest_time_calc|
     rest_time_calc.errors.messages
   end

--- a/app/serializers/rest_time_calc_serializer.rb
+++ b/app/serializers/rest_time_calc_serializer.rb
@@ -2,7 +2,7 @@ class RestTimeCalcSerializer
   include JSONAPI::Serializer
 
   set_id :user_id
-  attributes :asset_years, :asset_months
+  attributes :rest_years, :rest_months
   attributes :messages do |rest_time_calc|
     rest_time_calc.errors.messages
   end

--- a/spec/models/rest_month_calc_spec.rb
+++ b/spec/models/rest_month_calc_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe RestTimeCalc, type: :model do
+  let(:rest_time_calc) { RestMonthCalc.new(retirement_asset_calc, asset_config, asset_record) }
+  include_context :user_with_rest_time_calc_config
+
+  describe 'calculate' do
+    let(:result_years) { rest_time_calc.asset_years }
+    let(:relust_month) { rest_time_calc.asset_months }
+    let(:check_calc) { AssetFormationCalc.new(asset_config, asset_record) }
+
+    context '計算結果の年数と月数が経過したときの総資産額を検算した場合' do
+      subject { check_calc.asset_after_months(relust_month) }
+
+      it '引退目標の資産額を上回っている' do
+        is_expected.to be >= retirement_asset_calc.retirement_asset
+      end
+    end
+
+    context '計算結果の年数と月数の1月前の総資産額を検算した場合' do
+      subject { check_calc.asset_after_months(relust_month - 1) }
+
+      it '引退目標の資産額を下回っている' do
+        is_expected.to be <= retirement_asset_calc.retirement_asset
+      end
+    end
+  end
+
+  describe 'validation' do
+    context '必要な設定値が与えられていない場合' do
+      subject { rest_time_calc.errors.messages.size }
+      before { rest_time_calc.valid? }
+
+      context 'メイン設定値が与えられていない場合' do
+        let(:asset_config) { nil }
+        it 'バリデーションエラーが格納されている' do
+          is_expected.to eq 1
+        end
+      end
+
+      context 'リタイア額設定値が与えられていない場合' do
+        let(:retirement_asset_calc) { nil }
+        it 'バリデーションエラーが格納されている' do
+          is_expected.to eq 1
+        end
+      end
+    end
+  end
+end

--- a/spec/models/rest_month_calc_spec.rb
+++ b/spec/models/rest_month_calc_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe RestTimeCalc, type: :model do
   include_context :user_with_rest_time_calc_config
 
   describe 'calculate' do
-    let(:result_years) { rest_time_calc.asset_years }
-    let(:relust_month) { rest_time_calc.asset_months }
+    let(:result_years) { rest_time_calc.rest_years }
+    let(:relust_month) { rest_time_calc.rest_months }
     let(:check_calc) { AssetFormationCalc.new(asset_config, asset_record) }
 
     context '計算結果の年数と月数が経過したときの総資産額を検算した場合' do

--- a/spec/models/rest_time_calc_builder_spec.rb
+++ b/spec/models/rest_time_calc_builder_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RestTimeCalcBuilder, type: :model do
   describe 'new' do
     include_context :user_with_rest_time_calc_config
     let(:builder) { RestTimeCalcBuilder.new(user) }
-    subject { builder.rest_time_calc.asset_years }
+    subject { builder.rest_time_calc.rest_years }
 
     context '必要な設定値が与えられている場合' do
       it '計算結果として数字が返される' do

--- a/spec/models/rest_time_calc_spec.rb
+++ b/spec/models/rest_time_calc_spec.rb
@@ -5,12 +5,15 @@ RSpec.describe RestTimeCalc, type: :model do
   include_context :user_with_rest_time_calc_config
 
   describe 'calculate' do
-    let(:result_years) { rest_time_calc.asset_years }
-    let(:relust_month) { rest_time_calc.asset_months }
+    let(:result_years) { rest_time_calc.rest_years }
+    let(:result_month) { rest_time_calc.rest_months }
+    let(:result_days) { rest_time_calc.rest_days }
+    let(:passed_days) { (rest_time_calc.now - asset_record.date) / 60 / 60 / 24 }
+    let(:rest_months_from_last_record) { result_years * 12 + result_month + (result_days + passed_days.to_i) / 30 }
     let(:check_calc) { AssetFormationCalc.new(asset_config, asset_record) }
 
     context '計算結果の年数と月数が経過したときの総資産額を検算した場合' do
-      subject { check_calc.calculate!(result_years, relust_month) }
+      subject { check_calc.asset_after_months(rest_months_from_last_record) }
 
       it '引退目標の資産額を上回っている' do
         is_expected.to be >= retirement_asset_calc.retirement_asset
@@ -18,7 +21,7 @@ RSpec.describe RestTimeCalc, type: :model do
     end
 
     context '計算結果の年数と月数の1月前の総資産額を検算した場合' do
-      subject { check_calc.calculate!(result_years, relust_month - 1) }
+      subject { check_calc.asset_after_months(rest_months_from_last_record - 1) }
 
       it '引退目標の資産額を下回っている' do
         is_expected.to be <= retirement_asset_calc.retirement_asset

--- a/spec/requests/root_spec.rb
+++ b/spec/requests/root_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe "Root", :type => :request do
         expect(JSON.parse(response.body).dig("data", "type")).to eq "rest_time_calc"
       end
 
-      it "RestTimeCalcオブジェクトはasset_years, asset_months, messagesの3項目を返す" do
-        expect(attributes.keys).to eq ["asset_years", "asset_months", "messages"]
+      it "RestTimeCalcオブジェクトはrest_years, rest_months, messagesの3項目を返す" do
+        expect(attributes.keys).to eq ["rest_years", "rest_months", "messages"]
       end
 
       it 'レスポンスにエラーメッセージが含まれていない' do

--- a/spec/requests/root_spec.rb
+++ b/spec/requests/root_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Root", :type => :request do
       end
 
       it "RestTimeCalcオブジェクトはrest_years, rest_months, messagesの3項目を返す" do
-        expect(attributes.keys).to eq ["rest_years", "rest_months", "messages"]
+        expect(attributes.keys).to eq ["rest_years", "rest_months", "rest_days", "messages"]
       end
 
       it 'レスポンスにエラーメッセージが含まれていない' do

--- a/spec/support/authenticated_header_by_user_context.rb
+++ b/spec/support/authenticated_header_by_user_context.rb
@@ -17,6 +17,7 @@ shared_context :authenticated_header_by_user do
     certificate = double('certificate double')
     allow(certificate).to receive(:public_key).and_return('publick key mock')
     allow(OpenSSL::X509::Certificate).to receive(:new).and_return(certificate)
+    allow(Net::HTTP).to receive(:get).and_return('{}')
     allow(JWT).to receive(:decode).and_return([{"sub" => user.uuid}, {}])
   end
 end


### PR DESCRIPTION
## what
- 資産形成に必要な期間の算出ロジックをカウントダウンクラスから別クラスに分離
- カウントダウンクラスに、最後の資産記録月からの経過期間を計上するコードを追加
- もろもろテスト修正

## why
- 日数単位のカウントダウンによりアプリ名称(FIRE countdown app)にふさわしい仕様とした。