### PR TITLE
【仕様変更】リタイアまでの日数の仕様変更

### DIFF
--- a/app/controllers/api/v1/asset_record_controller.rb
+++ b/app/controllers/api/v1/asset_record_controller.rb
@@ -11,7 +11,7 @@ class Api::V1::AssetRecordController < ApplicationController
   private
 
   def set_asset_record
-    @asset_record = AssetRecord.find_or_initialize_by(user: @user, date: date_params)
+    @asset_record = AssetRecord.find_by_month_or_initialize_by(user: @user, date: date_params)
   end
 
   def create_response

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,6 @@ class ApplicationController < ActionController::Base
   include Locale
 
   def authenticate
-    pp jwt_token
     if jwt_token.present?
       @user = User.find_or_initialize_by(uuid: payload[0]["sub"])
       @user.save! if @user.new_record?

--- a/app/models/asset_formation_calc.rb
+++ b/app/models/asset_formation_calc.rb
@@ -20,4 +20,3 @@ class AssetFormationCalc
     sum
   end
 end
-

--- a/app/models/asset_record.rb
+++ b/app/models/asset_record.rb
@@ -6,7 +6,9 @@ class AssetRecord < ApplicationRecord
 
 	scope :latest_users_asset, -> (user) { where(user_id: user.id).order(:date).last }
 
-	def date=(value)
-		super AssetRecordDate.new(value).date
+	def self.find_by_month_or_initialize_by(arg)
+		date_range = arg[:date].to_date.beginning_of_month..arg[:date].to_date.end_of_month
+		record = find_by(arg.merge(date: date_range))
+		record || new(arg)
 	end
 end

--- a/app/models/asset_record_date.rb
+++ b/app/models/asset_record_date.rb
@@ -2,6 +2,6 @@ class AssetRecordDate
 	attr_reader :date
 
 	def initialize(value)
-		@date = Time.zone.parse(value).change(day: 1, hour: 0).to_formatted_s(:db)
+		@date = Time.zone.parse(value).change(hour: 0).to_formatted_s(:db)
 	end
 end

--- a/app/models/rest_month_calc.rb
+++ b/app/models/rest_month_calc.rb
@@ -13,6 +13,8 @@ class RestMonthCalc
   end
 
   def rest_months
+    return 0 unless asset_config && retirement_asset
+
     loop.with_index do |_, m|
       break m + 1 if asset_config.asset_after_one_month(asset_formation.asset_sum) > retirement_asset.retirement_asset
       asset_formation.asset_sum = asset_config.asset_after_one_month(asset_formation.asset_sum)

--- a/app/models/rest_time_calc.rb
+++ b/app/models/rest_time_calc.rb
@@ -8,41 +8,16 @@ class RestTimeCalc
     @user_id, @asset_config, @retirement_asset, @asset_record = user_id, asset_config, retirement_asset_calc, asset_record
   end
 
-  def rest_years
-    rest_ymd[0]
-  end
-
-  def rest_months
-    rest_ymd[1]
+  def retire_day
+    asset_record.date + rest_months_from_last_record.months
   end
 
   def rest_days
-    rest_ymd[2]
-  end
-  
-  def rest_ymd
-    return Array.new(3) { nil } if invalid?
-    [rest_period_days / 30 / 12, rest_period_days / 30 % 12, rest_period_days % 30]
+    (retire_day - Time.zone.today).to_i
   end
 
-  def rest_period_days
-    rest_months_from_last_record * 30 - passed_days
-  end
-  
   def rest_months_from_last_record
     @rest_months ||= RestMonthCalc.new(retirement_asset, asset_config, asset_record).rest_months
-  end
-
-  def passed_days
-    passed_unix_time / 60 / 60 / 24
-  end
-
-  def passed_unix_time
-    (now - asset_record.date).to_i 
-  end
-
-  def now
-    @now ||= Time.zone.now
   end
 
   def user

--- a/app/serializers/rest_time_calc_serializer.rb
+++ b/app/serializers/rest_time_calc_serializer.rb
@@ -2,8 +2,9 @@ class RestTimeCalcSerializer
   include JSONAPI::Serializer
 
   set_id :user_id
-  attributes :rest_years, :rest_months, :rest_days
+  attributes :retire_day, :rest_days
   attributes :messages do |rest_time_calc|
+    rest_time_calc.valid?
     rest_time_calc.errors.messages
   end
 

--- a/db/ridgepole.rb
+++ b/db/ridgepole.rb
@@ -12,7 +12,7 @@ end
 
 create_table "asset_records", force: :cascade do |t|
   t.string "amount", null: :false
-  t.datetime "date", null: :false
+  t.date "date", null: :false
   t.string "user_id", null: :false
   t.timestamps
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,7 +20,7 @@ ActiveRecord::Schema.define(version: 0) do
 
   create_table "asset_records", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "amount"
-    t.datetime "date"
+    t.date "date"
     t.string "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/models/asset_record_spec.rb
+++ b/spec/models/asset_record_spec.rb
@@ -1,12 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe AssetRecordDate, type: :model do
+  let(:user) { create(:user) }
+
   describe 'date' do
-    let(:user) { create(:user) }
     let(:asset_record) { create(:asset_record, date: date, user: user) }
-    let(:expected_time) { Time.zone.parse(date).at_beginning_of_day.to_s(:time) } 
+    let(:expected_time) { Time.zone.parse(date).at_beginning_of_day.to_s(:time) }
     subject { asset_record.date }
-    
+
     context '任意の日時を渡した場合' do
       let(:date) { '2021-01-31 12:34:56' }
       it '登録した年が返される' do
@@ -17,21 +18,42 @@ RSpec.describe AssetRecordDate, type: :model do
         expect(subject.month).to eq Time.zone.parse(date).month
       end
 
-      it '日は常に1日が返される' do
-        expect(subject.day).to eq 1
-      end
-
-      it '時刻は常に00:00が返される' do
-        expect(subject.to_s(:time)).to eq expected_time
+      it '登録した日が返される' do
+        expect(subject.day).to eq Time.zone.parse(date).day
       end
     end
   end
 
+  describe 'find_by_month_or_initialize_by' do
+    let!(:old_asset_record) { create(:asset_record, user: user, date: Time.zone.today.beginning_of_month) }
+    subject { AssetRecord.find_by_month_or_initialize_by(date: date) }
+
+    context 'old_asset_record.dateと同じ月内の異なる日付が渡された場合' do
+      let(:date) { Time.zone.today.end_of_month }
+
+      it 'old_asset_recordが取得される' do
+        is_expected.to eq old_asset_record
+      end
+    end
+
+    context 'old_asset_record.dateと異なる月の日付が渡された場合' do
+      let(:date) { Time.zone.today + 1.month }
+
+      it '新しいオブジェクトが生成される' do
+        expect(subject.new_record?).to be_truthy
+      end
+
+      it 'dateの値が正常' do
+        expect(subject.date).to eq date
+      end
+    end
+  end
+
+
   describe 'validation' do
-    let(:user) { create(:user) }
     let(:date) { '2021-01-31 12:34:56' }
 
-    context 'ユニーク制約' do 
+    context 'ユニーク制約' do
       let!(:asset_record) { create(:asset_record, date: date, user: user) }
       context '同じユーザー、同じ年月のレコードの場合' do
         let(:new_asset_record) { build(:asset_record, date: new_record_date, user: user) }
@@ -52,7 +74,7 @@ RSpec.describe AssetRecordDate, type: :model do
           expect(new_asset_record.errors[:date]).to eq []
         end
       end
-  
+
       context '同じユーザー、別の年月のレコードの場合' do
         let(:new_asset_record) { build(:asset_record, date: new_record_date, user: user) }
         let(:new_record_date) { Time.zone.parse(date).change(month: 12).to_s }
@@ -61,7 +83,7 @@ RSpec.describe AssetRecordDate, type: :model do
         it 'エラーは発生しない' do
           expect(new_asset_record.errors[:date]).to eq []
         end
-      end    
+      end
     end
   end
 end

--- a/spec/models/rest_time_calc_builder_spec.rb
+++ b/spec/models/rest_time_calc_builder_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RestTimeCalcBuilder, type: :model do
   describe 'new' do
     include_context :user_with_rest_time_calc_config
     let(:builder) { RestTimeCalcBuilder.new(user) }
-    subject { builder.rest_time_calc.rest_years }
+    subject { builder.rest_time_calc.rest_days }
 
     context '必要な設定値が与えられている場合' do
       it '計算結果として数字が返される' do

--- a/spec/models/rest_time_calc_spec.rb
+++ b/spec/models/rest_time_calc_spec.rb
@@ -4,28 +4,19 @@ RSpec.describe RestTimeCalc, type: :model do
   let(:rest_time_calc) { RestTimeCalc.new(retirement_asset_calc, user.id, asset_config, asset_record) }
   include_context :user_with_rest_time_calc_config
 
-  describe 'calculate' do
-    let(:result_years) { rest_time_calc.rest_years }
-    let(:result_month) { rest_time_calc.rest_months }
-    let(:result_days) { rest_time_calc.rest_days }
-    let(:passed_days) { (rest_time_calc.now - asset_record.date) / 60 / 60 / 24 }
-    let(:rest_months_from_last_record) { result_years * 12 + result_month + (result_days + passed_days.to_i) / 30 }
-    let(:check_calc) { AssetFormationCalc.new(asset_config, asset_record) }
+  describe 'retire_day' do
+    subject { rest_time_calc.retire_day }
 
-    context '計算結果の年数と月数が経過したときの総資産額を検算した場合' do
-      subject { check_calc.asset_after_months(rest_months_from_last_record) }
-
-      it '引退目標の資産額を上回っている' do
-        is_expected.to be >= retirement_asset_calc.retirement_asset
-      end
+    context '正常系' do
+      it { expect { subject }.to_not raise_error }
     end
+  end
 
-    context '計算結果の年数と月数の1月前の総資産額を検算した場合' do
-      subject { check_calc.asset_after_months(rest_months_from_last_record - 1) }
+  describe 'rest_days' do
+    subject { rest_time_calc.rest_days }
 
-      it '引退目標の資産額を下回っている' do
-        is_expected.to be <= retirement_asset_calc.retirement_asset
-      end
+    context '正常系' do
+      it { expect { subject }.to_not raise_error }
     end
   end
 

--- a/spec/requests/asset_record_spec.rb
+++ b/spec/requests/asset_record_spec.rb
@@ -7,11 +7,12 @@ RSpec.describe "AssetRecord", :type => :request do
     let(:user) { create(:user) }
     let(:attributes) { JSON.parse(response.body).dig("data", "attributes") }
     let(:asset_record_attributes) { attributes_for(:asset_record) }
-#JWTクラスに持っくる
+
     before do
       Api::V1::AssetRecordController.new.instance_variable_set(:@user, user)
       post api_v1_asset_record_index_path, headers: headers, params: { asset_record: asset_record_attributes }
     end
+
     context "正常系" do
       it "レスポンスオブジェクトはstatus, messagesの2項目を返す" do
         expect(attributes.keys).to eq ["status", "message"]

--- a/spec/requests/root_spec.rb
+++ b/spec/requests/root_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe "Root", :type => :request do
         expect(JSON.parse(response.body).dig("data", "type")).to eq "rest_time_calc"
       end
 
-      it "RestTimeCalcオブジェクトはrest_years, rest_months, messagesの3項目を返す" do
-        expect(attributes.keys).to eq ["rest_years", "rest_months", "rest_days", "messages"]
+      it "RestTimeCalcオブジェクトはretire_day, rest_days, messagesの3項目を返す" do
+        expect(attributes.keys).to include("retire_day", "rest_days", "messages")
       end
 
       it 'レスポンスにエラーメッセージが含まれていない' do


### PR DESCRIPTION
## what
- 資産レコードのdateカラムの仕様を変更
  - 日まで保存できる
- 引退までの期間を返すエンドポイントの仕様変更
  - 年月日に変換せず、日数で返す仕様に変更
  - 引退する日付も返す

## why
- ユーザーが必要な情報をクライアントアプリ側で提供しやすくするため